### PR TITLE
Install Python3 during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,13 @@ RUN apk update \
     && apk add --no-cache libc6-compat \
     && ln -s /lib/libc.musl-x86_64.so.1 /lib/ld-linux-x86-64.so.2
 
-# Git and Wget
-RUN apk add --update \
+# Git, Wget, Python3;
+# ln python3 to python, to make /spark/bin/pyspark happy.
+RUN apk --no-cache --virtual build-dependencies add --update \
     git \
-    wget
+    wget \
+    && apk add python3 \
+    && ln -sf /usr/bin/python3 /usr/local/bin/python
 
 # Sample resources
 RUN git clone https://github.com/archivesunleashed/aut-resources.git
@@ -38,5 +41,7 @@ RUN mkdir /spark \
     && wget -q "https://archive.apache.org/dist/spark/spark-$SPARK_VERSION/spark-$SPARK_VERSION-bin-hadoop2.7.tgz" \
     && tar -xf "/tmp/spark-$SPARK_VERSION-bin-hadoop2.7.tgz" -C /spark --strip-components=1 \
     && rm "/tmp/spark-$SPARK_VERSION-bin-hadoop2.7.tgz"
+
+RUN apk del build-dependencies
 
 CMD /spark/bin/spark-shell --packages "io.archivesunleashed:aut:0.70.1-SNAPSHOT"


### PR DESCRIPTION
Install Python3 during Docker build.

Link `/usr/bin/python3` to `/usr/local/bin/python`, because `/spark/bin/pyspark` expects a Python executable named `python`.

Remove build dependencies (git, wget) after build.

This supersedes #20.